### PR TITLE
chore(terraform): update required_version to >= 1.3

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 3.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Updates the required Terraform version from >= 1.1.9 to >= 1.3 to 
ensure compatibility with new features and improvements. This 
change enhances the stability and functionality of the Terraform 
configuration.